### PR TITLE
ios_HOST_OS implies darwin_HOST_OS

### DIFF
--- a/ios.patch
+++ b/ios.patch
@@ -1,62 +1,13 @@
---- ./rts/posix/GetTime.c.og	2021-06-29 00:24:51.000000000 -0700
-+++ ./rts/posix/GetTime.c	2021-06-29 00:24:51.000000000 -0700
-@@ -25,7 +25,7 @@
- #error No implementation for getProcessCPUTime() available.
- #endif
+--- ./includes/ghcconfig.h.og	2021-06-29 00:24:51.000000000 -0700
++++ ./includes/ghcconfig.h	2021-06-29 00:24:51.000000000 -0700
+@@ -2,3 +2,7 @@
  
--#if defined(darwin_HOST_OS)
-+#if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
- #include <mach/mach_time.h>
- #include <mach/mach_init.h>
- #include <mach/thread_act.h>
-@@ -36,14 +36,14 @@
- // we'll implement getProcessCPUTime() and getProcessElapsedTime()
- // separately, using getrusage() and gettimeofday() respectively
- 
--#if defined(darwin_HOST_OS)
-+#if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
- static uint64_t timer_scaling_factor_numer = 0;
- static uint64_t timer_scaling_factor_denom = 0;
- #endif
- 
- void initializeTimer()
- {
--#if defined(darwin_HOST_OS)
-+#if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
-     mach_timebase_info_data_t info;
-     (void) mach_timebase_info(&info);
-     timer_scaling_factor_numer = (uint64_t)info.numer;
-@@ -70,7 +70,7 @@
-     // N.B. Since macOS Catalina, Darwin supports clock_gettime but does not
-     // support clock_getcpuclockid. Hence we prefer to use the Darwin-specific
-     // path on Darwin, even if clock_gettime is available.
--#if defined(darwin_HOST_OS)
-+#if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
-     thread_basic_info_data_t info = { };
-     mach_msg_type_number_t info_count = THREAD_BASIC_INFO_COUNT;
-     kern_return_t kern_err = thread_info(mach_thread_self(), THREAD_BASIC_INFO,
---- ./rts/sm/Storage.c.og	2021-06-29 00:24:51.000000000 -0700
-+++ ./rts/sm/Storage.c	2021-06-29 00:24:51.000000000 -0700
-@@ -1644,7 +1644,7 @@
-     RELEASE_SM_LOCK
- }
- 
--#elif defined(USE_LIBFFI_FOR_ADJUSTORS) && defined(darwin_HOST_OS)
-+#elif defined(USE_LIBFFI_FOR_ADJUSTORS) && (defined(ios_HOST_OS) || defined(darwin_HOST_OS))
- 
- static HashTable* allocatedExecs;
- 
---- ./includes/rts/storage/GC.h.og	2021-06-29 00:24:51.000000000 -0700
-+++ ./includes/rts/storage/GC.h	2021-06-29 00:24:51.000000000 -0700
-@@ -199,7 +199,7 @@
- 
- AdjustorWritable allocateExec(W_ len, AdjustorExecutable *exec_addr);
- void flushExec(W_ len, AdjustorExecutable exec_addr);
--#if defined(darwin_HOST_OS)
-+#if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
- AdjustorWritable execToWritable(AdjustorExecutable exec);
- #endif
- 
+ #include "ghcautoconf.h"
+ #include "ghcplatform.h"
++
++#if defined(ios_HOST_OS)
++#define darwin_HOST_OS 1
++#endif
 --- ./llvm-targets.og	2021-06-29 00:24:51.000000000 -0700
 +++ ./llvm-targets	2021-06-29 00:24:51.000000000 -0700
 @@ -40,6 +40,7 @@


### PR DESCRIPTION
Simplify `ios.patch` logic by having `#define ios_HOST_OS` imply `#define darwin_HOST_OS`.